### PR TITLE
Fix README command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cmd.prependArgument({
   prefix: '-t'
 });
 
-command.exec();
+cmd.exec();
 ```
 
 **2. And had this pattern file**


### PR DESCRIPTION
## Summary
- fix the code snippet in README to use `cmd.exec()` instead of `command.exec()`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6842fff87b24832f8c282a408adca1fc