### PR TITLE
Support multiple glob patterns

### DIFF
--- a/__tests__/unit/fileUtils.spec.ts
+++ b/__tests__/unit/fileUtils.spec.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import { FileUtils } from '../../src/utils';
+
+describe('searchFilesForPatterns', () => {
+  test('it should find files for multiple patterns', () => {
+    const utils = new FileUtils();
+    const rootDir = path.join(__dirname, '../e2e/data');
+    const patterns = ['**/*.env', '**/*.vol'];
+    const files = utils.searchFilesForPatterns(patterns, rootDir);
+
+    const expected = [
+      path.join(rootDir, 'test.env'),
+      path.join(rootDir, 'test.vol')
+    ];
+
+    expect(files).toEqual(expect.arrayContaining(expected));
+    expect(files.length).toBe(expected.length);
+  });
+});

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -54,7 +54,6 @@ export default class FileUtils implements IFileUtils {
   }
 
   public searchFilesForPatterns(patterns: string[], rootDir: string): string[] {
-    const searchPattern = patterns.join('|');
     const globOptions = {
       cwd: rootDir,
       nodir: true,
@@ -62,6 +61,13 @@ export default class FileUtils implements IFileUtils {
       root: rootDir
     };
 
-    return this.globInstance.sync(searchPattern, globOptions);
+    let files: string[] = [];
+
+    patterns.forEach(pattern => {
+      const matches = this.globInstance.sync(pattern, globOptions);
+      files = files.concat(matches);
+    });
+
+    return files;
   }
 }


### PR DESCRIPTION
## Summary
- update `searchFilesForPatterns` to iterate over patterns
- add unit test verifying multiple pattern search

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6843046dcf74832fba346914e2d29ef8