### PR TITLE
Update exec callback signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,8 @@ getAllCommands(): ICommand[];
  * @param stderr Callback on STDERR
  */
 exec(
-  stdout?: (chunk: string) => string,
-  stderr?: (chunk: string) => string
+  stdout?: (chunk: string) => void,
+  stderr?: (chunk: string) => void
 ): ICommandProcess;
 
 /**

--- a/src/api/command.d.ts
+++ b/src/api/command.d.ts
@@ -5,8 +5,8 @@ interface ICommand {
    * @param stderr Callback on STDERR
    */
   exec(
-    stdout?: (chunk: string) => string,
-    stderr?: (chunk: string) => string
+    stdout?: (chunk: string) => void,
+    stderr?: (chunk: string) => void
   ): ICommandProcess;
 
   /**


### PR DESCRIPTION
## Summary
- change `exec` callback types to return `void`
- update README to match new signature

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68430117d6d8832fbfb2f97c0d026ecd