### PR TITLE
Add FileUtils tests and handle empty patterns

### DIFF
--- a/__tests__/__mocks__/basic.ts
+++ b/__tests__/__mocks__/basic.ts
@@ -15,6 +15,6 @@ export const createBuilder = (
   extraUtils?: IUtilsParam
 ): Builder => {
   const newUtils = utilFactory(extraUtils);
-  const newBuilder = new Builder({ rootDir: __dirname, ...options }, newUtils);
+  const newBuilder = new Builder({ rootDir: import.meta.dirname, ...options }, newUtils);
   return newBuilder;
 };

--- a/__tests__/e2e/e2e.spec.ts
+++ b/__tests__/e2e/e2e.spec.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { Builder } from '../../src';
 import Command from '../../src/command';
 
-const rootDir = path.join(__dirname, 'data');
+const rootDir = path.join(import.meta.dirname, 'data');
 
 const extensions: IArgumentFilePatterns[] = [
   {

--- a/__tests__/unit/fileUtils.spec.ts
+++ b/__tests__/unit/fileUtils.spec.ts
@@ -4,7 +4,7 @@ import { FileUtils } from '../../src/utils';
 describe('searchFilesForPatterns', () => {
   test('it should find files for multiple patterns', () => {
     const utils = new FileUtils();
-    const rootDir = path.relative(process.cwd(), path.join(__dirname, '../e2e/data'));
+    const rootDir = path.join(import.meta.dirname, '../e2e/data');
     const patterns = ['**/*.env', '**/*.vol'];
     const files = utils.searchFilesForPatterns(patterns, rootDir);
 
@@ -15,5 +15,43 @@ describe('searchFilesForPatterns', () => {
 
     expect(files).toEqual(expect.arrayContaining(expected));
     expect(files.length).toBe(expected.length);
+  });
+
+  test('it should find .env and .vol files', () => {
+    const utils = new FileUtils();
+    const rootDir = path.join(import.meta.dirname, '../e2e/data');
+
+    const envFiles = utils.searchFilesForPatterns(['**/*.env'], rootDir);
+    const volFiles = utils.searchFilesForPatterns(['**/*.vol'], rootDir);
+
+    expect(envFiles).toEqual([path.join(rootDir, 'test.env')]);
+    expect(volFiles).toEqual([path.join(rootDir, 'test.vol')]);
+  });
+
+  test('it should return unique results for overlapping patterns', () => {
+    const utils = new FileUtils();
+    const rootDir = path.join(import.meta.dirname, '../e2e/data');
+
+    const patterns = ['**/*.*', '**/*.env'];
+    const files = utils.searchFilesForPatterns(patterns, rootDir);
+
+    const expected = [
+      path.join(rootDir, 'test.vol'),
+      path.join(rootDir, 'test.lbl'),
+      path.join(rootDir, 'test.env')
+    ];
+
+    expect(files).toEqual(expected);
+  });
+});
+
+describe('computeFileContents', () => {
+  test('it handles empty patterns', () => {
+    const utils = new FileUtils();
+    const patterns: IArgumentFilePatterns[] = [{ prefix: '--env', patterns: [] }];
+
+    const results = utils.computeFileContents(patterns);
+
+    expect(results[0].contents).toEqual([]);
   });
 });

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -32,7 +32,7 @@ export default class FileUtils implements IFileUtils {
       newArgument.files = argument;
       newArgument.contents = argument.patterns
         .map((file: string) => this.readFileAsArray(file))
-        .reduce((prev: string[], cur: string[]) => prev.concat(cur));
+        .reduce((prev: string[], cur: string[]) => prev.concat(cur), []);
       newArray.push(newArgument);
     });
 
@@ -54,9 +54,9 @@ export default class FileUtils implements IFileUtils {
   public searchFilesForPatterns(patterns: string[], rootDir: string): string[] {
     const globOptions = {
       nodir: true,
-      realpath: true,
-      root: rootDir
-    };
+      absolute: true,
+      cwd: rootDir
+    } as const;
 
     let files: string[] = [];
 
@@ -65,6 +65,6 @@ export default class FileUtils implements IFileUtils {
       files = files.concat(matches);
     });
 
-    return files;
+    return Array.from(new Set(files));
   }
 }


### PR DESCRIPTION
## Summary
- expand unit tests for FileUtils
- support empty patterns when computing file contents
- return unique search results and use cwd for file search
- use `import.meta.dirname` in tests

## Testing
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_68437a79d904832f991d46ce544998c9