### PR TITLE
Add command argument parser tests

### DIFF
--- a/__tests__/unit/commandUtils.spec.ts
+++ b/__tests__/unit/commandUtils.spec.ts
@@ -1,0 +1,39 @@
+import { CommandUtils } from '../../src/utils';
+
+describe('parseArgumentInput', () => {
+  const utils = new CommandUtils();
+
+  test('single string returns array with one argument object', () => {
+    const result = utils.parseArgumentInput('value');
+    expect(result.length).toBe(1);
+    expect(result).toEqual([{ argument: 'value' }]);
+  });
+
+  test('array of strings returns array of argument objects', () => {
+    const result = utils.parseArgumentInput(['foo', 'bar']);
+    expect(result.length).toBe(2);
+    expect(result).toEqual([
+      { argument: 'foo' },
+      { argument: 'bar' }
+    ]);
+  });
+
+  test('array mixing objects and strings', () => {
+    const input = [
+      { argument: 'one', prefix: '--opt' },
+      'two'
+    ];
+    const result = utils.parseArgumentInput(input);
+    expect(result.length).toBe(2);
+    expect(result).toEqual([
+      { argument: 'one', prefix: '--opt' },
+      { argument: 'two' }
+    ]);
+  });
+
+  test('empty array returns empty result', () => {
+    const result = utils.parseArgumentInput([]);
+    expect(result.length).toBe(0);
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CommandUtils.parseArgumentInput

## Testing
- `npx vitest run`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6843886454a0832fab70b437efdb3198