### PR TITLE
Add order assertion for getAllCommands

### DIFF
--- a/__tests__/unit/builder.spec.ts
+++ b/__tests__/unit/builder.spec.ts
@@ -1,0 +1,17 @@
+import * as mock from '../__mocks__/basic';
+
+describe('getAllCommands', () => {
+  test('it should return commands in creation order', () => {
+    const builder = mock.createBuilder();
+    const first = builder.createCommand('first');
+    const second = builder.createCommand('second');
+    const third = builder.createCommand('third');
+
+    const cmds = builder.getAllCommands();
+
+    expect(cmds.length).toBe(3);
+    expect(cmds[0]).toBe(first);
+    expect(cmds[1]).toBe(second);
+    expect(cmds[2]).toBe(third);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for getAllCommands order

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_684388c8678c832fa81ac6e55a744dbd