### PR TITLE
Add test for convertVariables false

### DIFF
--- a/__tests__/unit/options.spec.ts
+++ b/__tests__/unit/options.spec.ts
@@ -216,4 +216,15 @@ describe('creating commands with non-default builder options', () => {
 
     expect(cmd.toString()).toBe('test --env FOO=$BAR');
   });
+
+  test('it should not convert variables when option is false', () => {
+    const fs = mock.fs('FOO=%BAR%');
+    const utils = { file: new FileUtils(fs), log: mock.logUtils };
+
+    const builder = mock.createBuilder({ convertVariables: false }, utils);
+
+    const cmd = builder.createCommand('test', extensions);
+
+    expect(cmd.toString()).toBe('test --env FOO=%BAR%');
+  });
 });


### PR DESCRIPTION
## Summary
- add a unit test to ensure variables are not converted when `convertVariables` is `false`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684388f0ca7c832fa42b7878aaa17f34